### PR TITLE
add a more informative error when the compilation with mkl fails

### DIFF
--- a/configure
+++ b/configure
@@ -130,7 +130,9 @@ else
         if [ ${nerr} -eq 0 ];then
                 echo "...MKL found"
         else
-                echo "ERROR: no MKL found"
+                echo "ERROR: Problem with MKL"
+		echo "We get the following when trying to use it"
+                ifort -mkl test.f90 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core 
                 exit
         fi
         echo


### PR DESCRIPTION
With ifort 2021.5.0 one needs to use the -qmkl keyword instead of -mkl.
Currently, the error is hidden behind the message 'MKL not found'
Now the error message will be more informative and hopefully more useful. 